### PR TITLE
Use `latest` branch for Roave security advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -242,7 +242,7 @@
 		"johnpbloch/wordpress-core": "dev-master"
 	},
 	"require-dev": {
-		"roave/security-advisories": "dev-master"
+		"roave/security-advisories": "dev-latest"
 	},
 	"suggest": {
 		"psy/psysh": "Enhanced `wp shell` functionality"


### PR DESCRIPTION
See details here -> https://github.com/Roave/SecurityAdvisories#stability