### PR TITLE
Update branch name for restful command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -223,7 +223,7 @@
 		"wp-cli/package-command": "dev-main",
 		"wp-cli/php-cli-tools": "dev-master as 0.11.x-dev",
 		"wp-cli/profile-command": "dev-master",
-		"wp-cli/restful": "dev-master",
+		"wp-cli/restful": "dev-main",
 		"wp-cli/rewrite-command": "dev-main",
 		"wp-cli/role-command": "dev-main",
 		"wp-cli/scaffold-command": "dev-master",


### PR DESCRIPTION
Follow-up to the default branch name change in the restful repo.

See also https://github.com/wp-cli/restful/pull/129