### PR TITLE
Remove `platform` requirement to avoid pinning to older versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -248,9 +248,6 @@
         "psy/psysh": "Enhanced `wp shell` functionality"
     },
     "config": {
-        "platform": {
-            "php": "5.6.20"
-        },
         "process-timeout": 7200,
         "sort-packages": true,
         "allow-plugins": {


### PR DESCRIPTION
From conversation in https://wordpress.slack.com/archives/C02RP4T41/p1660231895609819