### PR TITLE
Throw an error if `GITHUB_TOKEN` isn't set

### DIFF
--- a/.maintenance/src/GitHub.php
+++ b/.maintenance/src/GitHub.php
@@ -71,6 +71,11 @@ class GitHub {
 		$prerelease = false,
 		$args = []
 	) {
+
+		if ( ! getenv( 'GITHUB_TOKEN' ) ) {
+			WP_CLI::error( 'GITHUB_TOKEN environment variable must be set.' );
+		}
+
 		$request_url = sprintf(
 			self::API_ROOT . 'repos/%s/releases',
 			$project


### PR DESCRIPTION
I keep running into this error when I forget to set `GITHUB_TOKEN`:

```
$ wp maintenance release generate db-command
--- wp-cli/db-command ---
Checking milestone '2.0.23'...
Milestone '2.0.23' does not have a matching release, generating one...
Generating the following release:
-----
Version 2.0.23 (v2.0.23)
- Fix PHP 8.1 fatal error with `--orderby=size` and `--size_format=mb` [[#230](https://github.com/wp-cli/db-command/pull/230)]

-----
Is the above correct? [y/n] y
Creating release Version 2.0.23 v2.0.23...
Error: Failed request to https://api.github.com/repos/wp-cli/db-command/releases
GitHub API returned: {"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#create-a-release"} (HTTP code 404)
```