### PR TITLE
Use proper variable substitution when sending over the GitHub Token

### DIFF
--- a/.maintenance/clone-all-repositories.php
+++ b/.maintenance/clone-all-repositories.php
@@ -16,7 +16,7 @@ $request = 'https://api.github.com/orgs/wp-cli/repos?per_page=100';
 $headers = '';
 $token   = getenv( 'GITHUB_TOKEN' );
 if ( ! empty( $token ) ) {
-	$headers  = '--header "Authorization: token $token"';
+	$headers  = "--header \"Authorization: Bearer $token\"";
 	$response = shell_exec( "curl -s {$headers} {$request}" );
 } else {
 	$response = shell_exec( "curl -s {$request}" );


### PR DESCRIPTION
My first Contributor's Day contribution!

It looks like we're not properly sending the GitHub token. This is important in company/conference environments where we might have hundreds of devs hitting GitHub APIs.

cc @schlessera 