### PR TITLE
Improve cloning/refresh script

### DIFF
--- a/.maintenance/clone-all-repositories.php
+++ b/.maintenance/clone-all-repositories.php
@@ -40,14 +40,15 @@ foreach ( $repositories as $repository ) {
 		continue;
 	}
 
+	$destination = isset( $clone_destination_map[ $repository->name ] ) ? $clone_destination_map[ $repository->name ] : $repository->name;
+
 	if ( ! is_dir( $repository->name ) ) {
-		$destination = isset( $clone_destination_map[ $repository->name ] ) ? $clone_destination_map[ $repository->name ] : '';
 		printf( "Fetching \033[32mwp-cli/{$repository->name}\033[0m...\n" );
 		$clone_url = getenv( 'GITHUB_ACTION' ) ? $repository->clone_url : $repository->ssh_url;
 		system( "git clone {$clone_url} {$destination}" );
 	}
 
-	$update_folders[] = $repository->name;
+	$update_folders[] = $destination;
 }
 
 $updates = implode( '\n', $update_folders );

--- a/.maintenance/refresh-repository.php
+++ b/.maintenance/refresh-repository.php
@@ -10,7 +10,7 @@ $path       = realpath( getcwd() . "/{$repository}" );
 printf( "--- Refreshing repository \033[32m{$repository}\033[0m ---\n" );
 
 printf( "Switching to latest \033[33mdefault\033[0m branch...\n" );
-system( "git --git-dir={$path}/.git --work-tree={$path} checkout $(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)" );
+system( "git --git-dir={$path}/.git --work-tree={$path} checkout $(git --git-dir={$path}/.git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)" );
 
 printf( "Pulling latest changes...\n" );
 system( "git --git-dir={$path}/.git --work-tree={$path} pull" );


### PR DESCRIPTION
Quick follow-up to #51 to avoid trying to refresh the `.github` folder.

Plus, correctly gets the default branch name for repos like `wp-cli/spyc` which still use `master` and not `main`.