### PR TITLE
Don’t run `version_compare` with `null`

### DIFF
--- a/.maintenance/src/Contrib_List_Command.php
+++ b/.maintenance/src/Contrib_List_Command.php
@@ -123,6 +123,9 @@ final class Contrib_List_Command {
 			$milestone  = array_reduce(
 				$milestones,
 				function ( $tag, $milestone ) {
+					if ( ! $tag ) {
+						return $milestone->title;
+					}
 					return version_compare( $milestone->title, $tag, '>' ) ? $milestone->title : $tag;
 				}
 			);

--- a/.maintenance/src/Release_Notes_Command.php
+++ b/.maintenance/src/Release_Notes_Command.php
@@ -115,6 +115,9 @@ final class Release_Notes_Command {
 		$milestone = array_reduce(
 			$milestones,
 			function ( $tag, $milestone ) {
+				if ( ! $tag ) {
+					return $milestone->title;
+				}
 				return version_compare( $milestone->title, $tag, '>' ) ? $milestone->title : $tag;
 			}
 		);


### PR DESCRIPTION
I ran into deprecation warnings where `$tag` was `null` when running these commands in preparation for the 2.9.0 release