### PR TITLE
Skip cloning `wp-cli/regenerate-readme` repo

### DIFF
--- a/.maintenance/clone-all-repositories.php
+++ b/.maintenance/clone-all-repositories.php
@@ -6,6 +6,7 @@ $skip_list = array(
 	'dash-docset-generator',
 	'ideas',
 	'package-index',
+	'regenerate-readme',
 	'sample-plugin',
 	'wp-cli-dev',
 	'wp-cli-roadmap',


### PR DESCRIPTION
The repo is archived.