### PR TITLE
Add link to database information

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order to make code changes to WP-CLI, you'll need to set up this `wp-cli-dev`
 2. Install all Composer dependencies for a complete `wp-cli-bundle` setup, while symlinking all of the previously cloned packages into the Composer `vendor` folder.
 3. Symlink all folder in `vendor` into corresponding `vendor` folders in each repository, thus making the centralized functionality based on Composer available in each repository subfolder.
 
-Before you can proceed further, you'll need to make sure you have [Composer](https://getcomposer.org/), PHP, and a functioning MySQL or MariaDB server on your local machine.
+Before you can proceed further, you'll need to make sure you have [Composer](https://getcomposer.org/), PHP, and a [functioning MySQL or MariaDB server on your local machine](https://github.com/wp-cli/wp-cli-tests?tab=readme-ov-file#the-database-credentials).
 
 Once the prerequisites are met, clone the GitHub repository and run the installation process:
 


### PR DESCRIPTION
Updates the README to provide a link to the [database information in `wp-cli-tests`](https://github.com/wp-cli/wp-cli-tests?tab=readme-ov-file#the-database-credentials). This will allow people with alternative setups for MySQL/MariaDB (e.g., Lando, Docker, wp-env) to access the information required to connect to the database during setup.

Part of WCUS Contributor Day: https://github.com/wp-cli/wp-cli/issues/5985